### PR TITLE
include timezone with date/time

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -42,6 +42,13 @@ const formatNumber = (value) => {
     return value.toString().replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,');
 };
 
+const formatDate = (value) => {
+    return value.toLocaleString('en-US', {
+        timeZone: 'UTC',
+        timeZoneName: 'short'
+    })
+}
+
 // time data
 let ts = Date.now(),
     date_ob = new Date(ts),
@@ -152,7 +159,7 @@ exports.covid19globaltracker = (c, d, r, u) => {
                 chars: borders
             });
     table.push(
-        [{colSpan:5,content:yellow('As of '+asof.toLocaleString()+' [Date:'+currentdate+']')}],
+        [{colSpan:5,content:yellow('As of ' + formatDate(asof) + ' [Date:'+currentdate+']')}],
         [magenta('Cases'), red('Deaths'), green('Recovered'), red('Mortality %'), green('Recovered %')],
         [formatNumber(cases), formatNumber(deaths), formatNumber(recovered), mortalityPercentage.toFixed(2), recoveredPercentage.toFixed(2)],
         [helpInfo],[sourceInfo],[repoInfo]
@@ -173,7 +180,7 @@ exports.covid19countrytracker = (n, c, tC, d, tD, r, a, cl, cPOM, u) => {
                 chars: borders
             });
     table.push(
-        [{colSpan:5,content:yellow('As of '+asof.toLocaleString()+' [Date:'+currentdate+']')}],
+        [{colSpan:5,content:yellow('As of ' + formatDate(asof)  + ' [Date:'+currentdate+']')}],
         [magenta('Cases'), red('Deaths'), green('Recovered'), cyan('Active'), cyanBright('Cases/Million')],
         [formatNumber(cases), formatNumber(deaths), formatNumber(recovered), formatNumber(active), formatNumber(casesPerOneMillion)],
         [magentaBright('Today Cases'), redBright('Today Deaths'), redBright('Critical'), red('Mortality %'), greenBright('Recovery %')],
@@ -195,7 +202,7 @@ exports.plainglobaltracker = (c, d, r, u) => {
     ${line}
     COVID-19 Tracker CLI v${pkg.version} - Global Update
     ${line}
-    As of ${asof.toLocaleString()} [Date: ${currentdate}]
+    As of ${formatDate(asof)} [Date: ${currentdate}]
     ${line}
     Cases       | ${formatNumber(cases)}
     Deaths      | ${formatNumber(deaths)}
@@ -232,7 +239,7 @@ exports.plaincountrytracker = (n, c, tC, d, tD, r, a, cl, cPOM, u) => {
     ${line}
     COVID-19 Tracker CLI v${pkg.version} - ${name} Update
     ${line}
-    As of ${asof.toLocaleString()} [Date: ${currentdate}]
+    As of ${formatDate(asof)} [Date: ${currentdate}]
     ${line}
     Cases           | ${formatNumber(cases)}
     Today Cases     | ${formatNumber(todayCases)}
@@ -284,7 +291,7 @@ exports.historyCountryTracker = (n, c, tC, d, tD, r, a, cl, cPOM, u, h, chartTyp
             chartData = chart.generate(h, chartType);
 
     table.push(
-        [{colSpan: 5, content: yellow(`As of ${asof.toLocaleString()} Date: [${currentdate}]`)}],
+        [{colSpan: 5, content: yellow(`As of ${formatDate(asof)} Date: [${currentdate}]`)}],
         [magenta('Cases'), red('Deaths'), green('Recovered'), cyan('Active'), cyanBright('Cases/Million')],
         [formatNumber(cases), formatNumber(deaths), formatNumber(recovered), formatNumber(active), formatNumber(casesPerOneMillion)],
         [magentaBright('Today Cases'), redBright('Today Deaths'), redBright('Critical'), red('Mortality %'), greenBright('Recovery %')],


### PR DESCRIPTION
When I first requested from the command line I was confused as to the time zone of the time in the response. This aims to solve that by making it clear what we're talking about.

In doing this, I also set UTC as the default time zone. While this is already what the production environment is returning doing this allowed consistent behavior across different development environments, etc.

Original:
![image](https://user-images.githubusercontent.com/11138610/78164239-142c4b00-740f-11ea-970c-2b4566805d31.png)

New behavior:
![image](https://user-images.githubusercontent.com/11138610/78164322-36be6400-740f-11ea-848e-cefe29f4e93b.png)
