### PR TITLE
Fixed wget functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ curl -L covid19.trackercli.com
 #### WGET
 
 ```bash
-wget -i https://covid19.trackercli.com && cat index.html
+wget -qO- https://covid19.trackercli.com
 ```
 
 #### HTTPie


### PR DESCRIPTION
Old method left behind a file. New method prints output straight to stdout and does not download file, similar to the curl.